### PR TITLE
Fixes an error when executing runSequence

### DIFF
--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -41,7 +41,7 @@
             uglify: require('gulp-uglify'),
             path: require('path'),
             NwBuilder: require('nw-builder'),
-            inSequence: require('run-sequence'),
+            inSequence: require('run-sequence').use(gulp),
             empty: require('gulp-empty')
         };
 


### PR DESCRIPTION
Hi Thorsten,

I just switched the build system of a project to your xplatform-build. 

I'm using `gulp-watch` for building some advanced watching tasks. Within this watchers I use runSequence to start one of my defined gulp tasks. With the current version of your xplatform-build, this will fail with:

```
throw new Error("Task "+t+" is not configured as a task on gulp.  If this is a submodule, you may need to use require('run-sequence').use(gulp).");
            ^

Error: Task private:web:compile:withSourceMaps is not configured as a task on gulp.  If this is a submodule, you may need to use require('run-sequence').use(gulp).
```

This PR does exactly what it proposed from the error message. It uses `require('run-sequence').use(gulp)` which enables starting tasks from within the watchers.
